### PR TITLE
Bring up to date with Hasql changes

### DIFF
--- a/hasql-migration.cabal
+++ b/hasql-migration.cabal
@@ -36,7 +36,6 @@ library
                             bytestring                  >= 0.10,
                             contravariant               >= 1.3,
                             cryptonite                  >= 0.11,
-                            data-default-class          >= 0.0.1,
                             directory                   >= 1.2,
                             hasql                       >= 1.3,
                             hasql-transaction           >= 0.7,

--- a/src/Hasql/Migration.hs
+++ b/src/Hasql/Migration.hs
@@ -37,7 +37,6 @@ module Hasql.Migration
 import Control.Arrow
 import Crypto.Hash (hashWith, MD5(..))
 import Data.ByteArray.Encoding
-import Data.Default.Class
 import Data.Functor.Contravariant
 import Data.List (isPrefixOf, sort)
 import Data.Time (LocalTime)
@@ -95,12 +94,14 @@ executeMigration name contents = do
             return Nothing
         ScriptNotExecuted -> do
             sql contents
-            statement (name, checksum) (Statement q (contramap (first T.pack) def) Decoders.unit False)
+            statement (name, checksum) (Statement q (contramap (first T.pack) encoder) Decoders.noResult False)
             return Nothing
         ScriptModified _ -> do
             return (Just $ ScriptChanged name)
     where
-        q = "insert into schema_migrations(filename, checksum) values($1, $2)"
+      encoder = (fst >$< Encoders.param (Encoders.nonNullable Encoders.text)) <>
+                (snd >$< Encoders.param (Encoders.nonNullable Encoders.text))
+      q = "insert into schema_migrations(filename, checksum) values($1, $2)"
 
 -- | Initializes the database schema with a helper table containing
 -- meta-information about executed migrations.
@@ -147,7 +148,7 @@ executeValidation cmd = case cmd of
 -- will be executed and its meta-information will be recorded.
 checkScript :: ScriptName -> Checksum -> Transaction CheckScriptResult
 checkScript name checksum =
-    statement name (Statement q (contramap T.pack (Encoders.param def)) (Decoders.rowMaybe (Decoders.column def)) False) >>= \case
+    statement name (Statement q (contramap T.pack (Encoders.param (Encoders.nonNullable Encoders.text))) (Decoders.rowMaybe (Decoders.column (Decoders.nonNullable Decoders.text))) False) >>= \case
         Nothing ->
             return ScriptNotExecuted
         Just actualChecksum | checksum == actualChecksum ->
@@ -201,7 +202,7 @@ data MigrationError = ScriptChanged String | NotInitialised | ScriptMissing Stri
 -- | Produces a list of all executed 'SchemaMigration's.
 getMigrations :: Transaction [SchemaMigration]
 getMigrations =
-    statement () $ Statement q def (Decoders.rowList decodeSchemaMigration) False
+    statement () $ Statement q Encoders.noParams (Decoders.rowList decodeSchemaMigration) False
     where
         q = mconcat
             [ "select filename, checksum, executed_at "
@@ -225,6 +226,6 @@ instance Ord SchemaMigration where
 decodeSchemaMigration :: Decoders.Row SchemaMigration
 decodeSchemaMigration =
     SchemaMigration
-    <$> Decoders.column def
-    <*> Decoders.column def
-    <*> Decoders.column def
+    <$> Decoders.column (Decoders.nonNullable Decoders.bytea)
+    <*> Decoders.column (Decoders.nonNullable Decoders.text)
+    <*> Decoders.column (Decoders.nonNullable Decoders.timestamp)

--- a/src/Hasql/Migration/Util.hs
+++ b/src/Hasql/Migration/Util.hs
@@ -21,12 +21,11 @@ import qualified Hasql.Encoders as Encoders
 import qualified Hasql.Decoders as Decoders
 import           Hasql.Transaction (statement, Transaction)
 import Data.Text (Text)
-import Data.Default.Class
 
 -- | Checks if the table with the given name exists in the database.
 existsTable :: Text -> Transaction Bool
 existsTable table =
     fmap (not . null) $ statement table q
     where
-        q = Statement sql (Encoders.param def) (Decoders.rowList (Decoders.column Decoders.int8)) False
+        q = Statement sql (Encoders.param $ Encoders.nonNullable Encoders.text) (Decoders.rowList (Decoders.column $ Decoders.nonNullable Decoders.int8)) False
         sql = "select relname from pg_class where relname = $1"

--- a/test/Hasql/MigrationTest.hs
+++ b/test/Hasql/MigrationTest.hs
@@ -31,7 +31,7 @@ migrationSpec :: Connection -> Spec
 migrationSpec con = describe "Migrations" $ do
     let migrationScript = MigrationScript "test.sql" q
     let migrationScriptAltered = MigrationScript "test.sql" ""
-    [migrationDir] <- runIO $ loadMigrationsFromDirectory "share/test/scripts"
+    migrationDir <- runIO $ head <$> loadMigrationsFromDirectory "share/test/scripts"
     migrationFile <- runIO $ loadMigrationFromFile "s.sql" "share/test/script.sql"
 
     it "initializes a database" $ do

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -25,4 +25,4 @@ main = do
     conE <- acquire "dbname=test"
     case conE of
       Right con -> hspec (migrationSpec con)
-      Left err -> putStrLn $ show err
+      Left err -> error $ show err


### PR DESCRIPTION
Updated code to run with the newest Hasql version and GHC 8.6.
Removed dependency on data-default since it has been dropped from Hasql.