### PR TITLE
Update to support GHC 9.12 and dependency change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 cabal.sandbox.config
 stack.yaml
 .stack-work
+dist-newstyle/

--- a/hasql-migration.cabal
+++ b/hasql-migration.cabal
@@ -1,6 +1,6 @@
 cabal-version:              3.4
 name:                       hasql-migration
-version:                    0.4.0
+version:                    0.4.1
 synopsis:                   PostgreSQL Schema Migrations
 homepage:                   https://github.com/tvh/hasql-migration
 Bug-reports:                https://github.com/tvh/hasql-migration/issues
@@ -34,11 +34,11 @@ library
     build-depends:          base                        >= 4.7 && < 5,
                             bytestring                  >= 0.10,
                             contravariant               >= 1.3,
-                            crypton                     >= 0.32,
+                            crypton                     >= 1.1.0,
                             directory                   >= 1.2,
                             hasql                       >= 1.10,
                             hasql-transaction           >= 0.7,
-                            memory,
+                            ram,
                             text                        >= 1.2,
                             time                        >= 1.4
 

--- a/hasql-migration.cabal
+++ b/hasql-migration.cabal
@@ -1,16 +1,16 @@
+cabal-version:              3.4
 name:                       hasql-migration
-version:                    0.3.1
+version:                    0.4.0
 synopsis:                   PostgreSQL Schema Migrations
 homepage:                   https://github.com/tvh/hasql-migration
 Bug-reports:                https://github.com/tvh/hasql-migration/issues
-license:                    BSD3
+license:                    BSD-3-Clause
 license-file:               License
 author:                     Timo von Holtz <tvh@tvholtz.net>
 maintainer:                 Timo von Holtz <tvh@tvholtz.net>
 copyright:                  Timo von Holtz, Andreas Meingast, Sumit Raja
 category:                   Database
 build-type:                 Simple
-cabal-version:              >= 1.10
 description:                A hasql schema migration utility
 extra-source-files:         License
                             Readme.markdown
@@ -23,7 +23,7 @@ extra-source-files:         License
 
 source-repository head
     type:                   git
-    location:               git://github.com/tvh/hasql-migration
+    location:               https://github.com/tvh/hasql-migration
 
 library
     exposed-modules:        Hasql.Migration
@@ -36,7 +36,7 @@ library
                             contravariant               >= 1.3,
                             crypton                     >= 0.32,
                             directory                   >= 1.2,
-                            hasql                       >= 1.4,
+                            hasql                       >= 1.10,
                             hasql-transaction           >= 0.7,
                             memory,
                             text                        >= 1.2,
@@ -51,7 +51,7 @@ test-suite hasql-migration-test
     type:                   exitcode-stdio-1.0
     build-depends:          base                        >= 4.7 && < 5,
                             bytestring                  >= 0.10,
-                            hasql                       >= 0.19,
+                            hasql                       >= 1.10,
                             hasql-migration,
                             hasql-transaction           >= 0.5,
                             hspec                       >= 2.2,

--- a/hasql-migration.cabal
+++ b/hasql-migration.cabal
@@ -36,7 +36,7 @@ library
                             contravariant               >= 1.3,
                             crypton                     >= 1.1.0,
                             directory                   >= 1.2,
-                            hasql                       >= 1.10,
+                            hasql                       >= 1.10.3,
                             hasql-transaction           >= 0.7,
                             ram,
                             text                        >= 1.2,

--- a/src/Hasql/Migration.hs
+++ b/src/Hasql/Migration.hs
@@ -44,7 +44,6 @@ import Hasql.Migration.Util (existsTable)
 import Hasql.Statement
 import Hasql.Transaction
 import System.Directory (getDirectoryContents)
-import Data.Semigroup ((<>))
 import qualified Data.ByteString as BS (ByteString, readFile)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -94,7 +93,7 @@ executeMigration name contents = do
             return Nothing
         ScriptNotExecuted -> do
             sql contents
-            statement (name, checksum) (Statement q enc Decoders.noResult False)
+            statement (name, checksum) (unpreparable q enc Decoders.noResult)
             return Nothing
         ScriptModified _ -> do
             return (Just $ ScriptChanged name)
@@ -147,8 +146,8 @@ executeValidation cmd = case cmd of
 -- will be executed and its meta-information will be recorded.
 checkScript :: ScriptName -> Checksum -> Transaction CheckScriptResult
 checkScript name checksum =
-    statement name (Statement q (contramap T.pack (Encoders.param (Encoders.nonNullable Encoders.text))) 
-        (Decoders.rowMaybe (Decoders.column (Decoders.nonNullable Decoders.text))) False) >>= \case
+    statement name (unpreparable q (contramap T.pack (Encoders.param (Encoders.nonNullable Encoders.text))) 
+        (Decoders.rowMaybe (Decoders.column (Decoders.nonNullable Decoders.text)))) >>= \case
         Nothing ->
             return ScriptNotExecuted
         Just actualChecksum | checksum == actualChecksum ->
@@ -157,7 +156,7 @@ checkScript name checksum =
             return (ScriptModified actualChecksum)
     where
         q = mconcat
-            [ "select checksum from schema_migrations "
+            [ "select checksum :: text from schema_migrations "
             , "where filename = $1 limit 1"
             ]
 
@@ -202,16 +201,16 @@ data MigrationError = ScriptChanged String | NotInitialised | ScriptMissing Stri
 -- | Produces a list of all executed 'SchemaMigration's.
 getMigrations :: Transaction [SchemaMigration]
 getMigrations =
-    statement () $ Statement q Encoders.noParams (Decoders.rowList decodeSchemaMigration) False
+    statement () $ unpreparable q Encoders.noParams (Decoders.rowList decodeSchemaMigration)
     where
         q = mconcat
-            [ "select filename, checksum, executed_at "
+            [ "select filename :: text, checksum :: text, executed_at "
             , "from schema_migrations order by executed_at asc"
             ]
 
 -- | A product type representing a single, executed 'SchemaMigration'.
 data SchemaMigration = SchemaMigration
-    { schemaMigrationName       :: BS.ByteString
+    { schemaMigrationName       :: T.Text
     -- ^ The name of the executed migration.
     , schemaMigrationChecksum   :: Checksum
     -- ^ The calculated MD5 checksum of the executed script.
@@ -226,6 +225,6 @@ instance Ord SchemaMigration where
 decodeSchemaMigration :: Decoders.Row SchemaMigration
 decodeSchemaMigration =
     SchemaMigration
-    <$> Decoders.column (Decoders.nonNullable Decoders.bytea)
+    <$> Decoders.column (Decoders.nonNullable Decoders.text)
     <*> Decoders.column (Decoders.nonNullable Decoders.text)
     <*> Decoders.column (Decoders.nonNullable Decoders.timestamp)

--- a/src/Hasql/Migration/Util.hs
+++ b/src/Hasql/Migration/Util.hs
@@ -27,5 +27,5 @@ existsTable :: Text -> Transaction Bool
 existsTable table =
     fmap (not . null) $ statement table q
     where
-        q = Statement sql (Encoders.param (Encoders.nonNullable Encoders.text)) (Decoders.rowList (Decoders.column (Decoders.nullable Decoders.int8))) False
-        sql = "select relname from pg_class where relname = $1"
+        q = unpreparable sql (Encoders.param (Encoders.nonNullable Encoders.text)) (Decoders.rowList (Decoders.column (Decoders.nullable Decoders.text)))
+        sql = "select relname :: text from pg_class where relname = $1"

--- a/test/Hasql/MigrationTest.hs
+++ b/test/Hasql/MigrationTest.hs
@@ -14,25 +14,34 @@
 
 module Hasql.MigrationTest where
 
-import           Hasql.Session                        (run, SessionError)
-import           Hasql.Connection
+import           Hasql.Connection ( Connection, use )
 import qualified Hasql.Transaction                    as Tx
 import qualified Hasql.Transaction.Sessions           as Tx
-import           Hasql.Migration
+import           Hasql.Migration (
+                  SchemaMigration(schemaMigrationName),
+                  MigrationError(ScriptChanged),
+                  MigrationCommand(MigrationValidation, MigrationScript,
+                                    MigrationInitialization),
+                  runMigration,
+                  loadMigrationsFromDirectory,
+                  loadMigrationFromFile,
+                  getMigrations )
 import           Hasql.Migration.Util                 (existsTable)
 import           Test.Hspec                           (Spec, describe, it,
                                                        shouldBe, runIO)
+import Hasql.Errors (SessionError)
+import Data.Maybe (listToMaybe)
 
 runTx :: Connection -> Tx.Transaction a -> IO (Either SessionError a)
 runTx con act = do
-    run (Tx.transaction Tx.ReadCommitted Tx.Write act) con
+    use con (Tx.transaction Tx.ReadCommitted Tx.Write act)
 
 migrationSpec :: Connection -> Spec
 migrationSpec con = describe "Migrations" $ do
     let migrationScript = MigrationScript "test.sql" q
     let migrationScriptAltered = MigrationScript "test.sql" ""
     mds <- runIO $ loadMigrationsFromDirectory "share/test/scripts"
-    let migrationDir = head mds 
+    migrationDir <- runIO $ maybe (fail "Expecting migration dir") pure (listToMaybe mds)
     migrationFile <- runIO $ loadMigrationFromFile "s.sql" "share/test/script.sql"
 
     it "initializes a database" $ do


### PR DESCRIPTION
Updates to support GHC 9.12, hasql and switch to ram instead of memory due to crypton dependencies. 